### PR TITLE
simple override for client name in sensu-client

### DIFF
--- a/lib/sensu/client.rb
+++ b/lib/sensu/client.rb
@@ -51,8 +51,10 @@ module Sensu
     end
 
     def publish_result(check)
+      client = check[:custom] && check[:custom][:override_client] ?
+                 check[:custom][:override_client] : @settings[:client][:name]
       payload = {
-        :client => @settings[:client][:name],
+        :client => client,
         :check => check
       }
       @logger.info('publishing check result', {


### PR DESCRIPTION
@solarkennedy @bobtfish @keymone @hashbrowncipher 

This is not for pushing, I just wanted to see what you all think about this simple change.

This (or something like this) will allow us to easily generate events from a host without tying said event to this host.

The override can be name of environment or any string that we want. I know there were some discussions about ability to masquerade in the past but I thought they involved some deep structural changes. Just wondering why not do something simple like this.
